### PR TITLE
healthcheck endpoint prefixed with /api/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Execution using Docker requires:
 
 Dependencies on other Microservices:
 - [GFW Areas](https://github.com/gfw-api/gfw-area)
-- [FW teams](https://github.com/gfw-api/fw-teams)
+- [FW teams](https://github.com/wri/fw_teams)
 
 ## Getting started
 

--- a/app/Gruntfile.js
+++ b/app/Gruntfile.js
@@ -30,21 +30,14 @@ module.exports = grunt => {
       },
       jssrc: {
         files: ["app/src/**/*.js"],
-        tasks: ["jshint:js", "mochaTest:unit", "express:dev"],
-        options: {
-          spawn: false
-        }
-      },
-      unitTest: {
-        files: ["app/test/unit/**/*.test.js"],
-        tasks: ["jshint:jsTest", "mochaTest:unit"],
+        tasks: ["express:dev"],
         options: {
           spawn: false
         }
       },
       e2eTest: {
         files: ["app/test/e2e/**/*.spec.js"],
-        tasks: ["jshint:jsTest", "mochaTest:e2e"],
+        tasks: ["mochaTest:e2e"],
         options: {
           spawn: false
         }

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -2,7 +2,6 @@ const config = require("config");
 const logger = require("logger");
 const path = require("path");
 const convert = require("koa-convert");
-const koaSimpleHealthCheck = require("koa-simple-healthcheck");
 const koa = require("koa");
 const koaLogger = require("koa-logger");
 const loader = require("loader");
@@ -70,8 +69,6 @@ app.use(function* handleErrors(next) {
   }
   this.response.type = "application/vnd.api+json";
 });
-
-app.use(convert.back(koaSimpleHealthCheck()));
 
 app.use(
   convert.back(async (ctx, next) => {

--- a/app/src/routes/api/v1/healthcheck.router.js
+++ b/app/src/routes/api/v1/healthcheck.router.js
@@ -1,0 +1,11 @@
+const Router = require("koa-router");
+const convert = require("koa-convert");
+const koaSimpleHealthCheck = require("koa-simple-healthcheck");
+
+const router = new Router({
+  prefix: "/healthcheck"
+});
+
+router.get("/", convert.back(koaSimpleHealthCheck()));
+
+module.exports = router;

--- a/app/test/e2e/health-check.spec.js
+++ b/app/test/e2e/health-check.spec.js
@@ -6,7 +6,7 @@ chai.should();
 
 let requester;
 
-describe("GET healthcheck", function () {
+describe("GET /api/v1/healthcheck", function () {
   // eslint-disable-next-line mocha/no-hooks-for-single-case
   before(async function () {
     if (process.env.NODE_ENV !== "test") {
@@ -19,7 +19,7 @@ describe("GET healthcheck", function () {
   });
 
   it("Checking the application's health should return a 200", async function () {
-    const response = await requester.get("/healthcheck");
+    const response = await requester.get("/api/v1/healthcheck");
 
     response.status.should.equal(200);
     response.body.should.be.an("object").and.have.property("uptime");


### PR DESCRIPTION
The health check endpoint is now `/api/v1/healthcheck` instead of `/healthcheck`

`convert.back()` is used because koa is running an old version.

Tests pass as before.

Gruntfile updated to remove jshint tasks as they don't exist anymore.