### PR TITLE
local mongoDB initialises admin user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules/
+data/

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -19,9 +19,12 @@ const koaBody = require("koa-body")({
 });
 const loggedInUserService = require("./services/LoggedInUserService");
 
-const mongoUri = `mongodb://${config.get("mongodb.host")}:${config.get("mongodb.port")}/${config.get(
-  "mongodb.database"
-)}`;
+const mongoURL =
+  "mongodb://" +
+  `${config.get("mongodb.username")}:${config.get("mongodb.secret.password")}` +
+  `@${config.get("mongodb.host")}:${config.get("mongodb.port")}` +
+  `/${config.get("mongodb.database")}`;
+
 mongoose.Promise = Promise;
 
 const onDbReady = err => {
@@ -31,7 +34,7 @@ const onDbReady = err => {
   }
 };
 
-mongoose.connect(mongoUri, onDbReady);
+mongoose.connect(mongoURL, onDbReady);
 
 const app = koa();
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -5,8 +5,13 @@
   "legacyTemplateId": "LEGACY_TEMPLATE_ID",
   "defaultTemplateId": "DEFAULT_TEMPLATE_ID",
   "mongodb": {
+    "database": "DB_DATABASE",
     "host": "MONGO_PORT_27017_TCP_ADDR",
-    "port": "MONGO_PORT_27017_TCP_PORT"
+    "port": "MONGO_PORT_27017_TCP_PORT",
+    "username": "DB_USERNAME",
+    "secret": {
+      "password": "DB_SECRET_PASSWORD"
+    }
   },
   "s3": {
     "accessKeyId": "S3_ACCESS_KEY_ID",

--- a/config/default.json
+++ b/config/default.json
@@ -66,7 +66,11 @@
     "mongodb": {
         "database": "gfw_forms",
         "host": "mymachine",
-        "port": 27017
+        "port": 27017,
+        "username": "admin",
+        "secret": {
+            "password": "password"
+        }
     },
     "s3":{
         "accessKeyId": null,

--- a/data/mongo/001_users.js
+++ b/data/mongo/001_users.js
@@ -4,7 +4,7 @@ db.createUser({
   roles: [
     {
       role: "readWrite",
-      db: "mydatabase"
+      db: "gfw_forms"
     }
   ]
 });

--- a/data/mongo/001_users.js
+++ b/data/mongo/001_users.js
@@ -1,0 +1,10 @@
+db.createUser({
+  user: "admin",
+  pwd: "password",
+  roles: [
+    {
+      role: "readWrite",
+      db: "mydatabase"
+    }
+  ]
+});

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -11,6 +11,9 @@ services:
       NODE_ENV: dev
       SUPPRESS_NO_CONFIG_WARNING: "true"
       MONGO_PORT_27017_TCP_ADDR: mongo
+      DB_USERNAME: admin
+      DB_SECRET_PASSWORD: password
+      DB_DATABASE: gfw_forms
       CT_URL: https://api.resourcewatch.org
       LOCAL_URL: http://127.0.0.1:4401
       TEAMS_API_URL: http://fw-teams-develop:3035/api/v1
@@ -34,11 +37,19 @@ services:
     container_name: gfw-forms-mongo
     ports:
       - "27024:27017"
+    environment:
+      MONGO_INITDB_DATABASE: gfw_forms
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: admin
     volumes:
-      - $HOME/docker/data/gfw-forms-api/mongodb:/data/db
+      - ./data/mongo/001_users.js:/docker-entrypoint-initdb.d/001_users.js:ro
+      - gfw-forms-mongodb-data:/data/db
     restart: always
     networks:
       - gfw-forms-network
+
+volumes:
+  gfw-forms-mongodb-data:
 
 networks:
   gfw-forms-network:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -11,6 +11,9 @@ services:
       NODE_ENV: test
       SUPPRESS_NO_CONFIG_WARNING: "true"
       MONGO_PORT_27017_TCP_ADDR: mongo
+      DB_USERNAME: admin
+      DB_SECRET_PASSWORD: password
+      DB_DATABASE: gfw_forms
       CT_URL: http://127.0.0.1:9000
       LOCAL_URL: http://127.0.0.1:4400
       TEAMS_API_URL: http://127.0.0.1:9000
@@ -29,3 +32,13 @@ services:
     command: --smallfiles
     ports:
       - "27017"
+    environment:
+      MONGO_INITDB_DATABASE: gfw_forms
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: admin
+    volumes:
+      - ./data/mongo/001_users.js:/docker-entrypoint-initdb.d/001_users.js:ro
+      - gfw-forms-mongodb-data::/data/db
+
+volumes:
+  gfw-forms-mongodb-data:

--- a/terraform/templates/container_definition.json.tmpl
+++ b/terraform/templates/container_definition.json.tmpl
@@ -25,6 +25,10 @@
       "value" : "${mongo_port_27017_tcp_addr}"
     },
     {
+      "name": "DB_USERNAME",
+      "value" : "${db_secret_arn.username}"
+    }
+    {
       "name" : "CT_URL",
       "value" : "${ct_url}"
     },
@@ -65,14 +69,19 @@
     {
       "name": "DB_SECRET",
       "valueFrom": "${db_secret_arn}"
-    },{
+    },
+    {
+      "name": "DB_SECRET_PASSWORD",
+      "valueFrom": "${db_secret_arn.password}"
+    }
+    {
       "name": "GOOGLE_PRIVATE_KEY",
        "valueFrom": "${google_private_key}"
-      },
-      {
+    },
+    {
       "name": "GOOGLE_PROJECT_EMAIL",
        "valueFrom": "${google_project_email}"
-      }
+    }
   ],
   "portMappings": [
     {


### PR DESCRIPTION
Now locally when the MongoDB is initialised an admin user is created, following the technique described [here](https://github.com/docker-library/mongo/issues/174#issuecomment-449984230) and [here](https://dev.to/emmysteven/how-not-to-configure-mongodb-on-docker-nbn). This is to mimic the behaviour on production.

The local MongoDB data is now sorted in a named volume so it's easier to work with locally! e.g. `docker volume rm gfw-forms-mongodb-data`

The container template used in terraform has been updated so that the database's username and password are now added as environment variables.