### PR TITLE
healthcheck endpoint 404 fix

### DIFF
--- a/app/src/routes/v1/fw_forms/healthcheck.router.js
+++ b/app/src/routes/v1/fw_forms/healthcheck.router.js
@@ -1,11 +1,10 @@
 const Router = require("koa-router");
-const convert = require("koa-convert");
 const koaSimpleHealthCheck = require("koa-simple-healthcheck");
 
 const router = new Router({
   prefix: "/healthcheck"
 });
 
-router.get("/", convert.back(koaSimpleHealthCheck()));
+router.get("/", koaSimpleHealthCheck());
 
 module.exports = router;


### PR DESCRIPTION
Looks like we can't use convert.back as we have that "catch all" fix for the convert function at the top of app.js.

The healthcheck endpoint for returning 404, so AWS couldn't verify the app was running and so was stop starting the instance in a loop.

This fixes that and the healthcheck endpoint now returns 200 :)