### PR TITLE
High: staging urls updated for the dev environment (tiny)

### DIFF
--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -10,7 +10,7 @@ wri_mail_recipients       = "owen@3sidedcube.com,edward@3sidedcube.com,ben.sherr
 
 node_env                  = "dev"
 ct_url                    = "https://staging-api.resourcewatch.org"
-areas_api_url             = "https://gfw-staging.globalforestwatch.org/v1"
+areas_api_url             = "https://staging-api.resourcewatch.org/v1"
 api_api_url               = "https://dev-fw-api.globalforestwatch.org/v3/forest-watcher"
 s3_access_key_id          = "overridden_in_github_secrets"
 s3_secret_access_key      = "overridden_in_github_secrets"


### PR DESCRIPTION
`https://gfw-staging.globalforestwatch.org` has gone down, needs to be replaced with `https://staging-api.resourcewatch.org`