### PR TITLE
High: managers to see all report answers (tiny)

### DIFF
--- a/app/src/services/answersService.js
+++ b/app/src/services/answersService.js
@@ -22,7 +22,7 @@ class AnswersService {
       filter = {
         $and: [{ report: new ObjectId(reportId) }]
       };
-    } else if (currentManager && template.public) {
+    } else if (currentManager) {
       // managers can check all answers from the default template from his and his team's members
       filter = {
         $and: [

--- a/docs/fw_forms.yaml
+++ b/docs/fw_forms.yaml
@@ -472,6 +472,7 @@ components:
         public:
           type: boolean
           default: false
+          deprecated: true
         createdAt:
           type: string
           format: date-time


### PR DESCRIPTION
Managers should be able to see all report answers from themselves and their team members.

Currently the public flag is blocking this from happening.

The public flag can't be set by the UI to true so we've removed it.

Also deprecated it within the docs